### PR TITLE
Switch from unbound to unbound-generics

### DIFF
--- a/disco.cabal
+++ b/disco.cabal
@@ -64,7 +64,7 @@ library
                        split >= 0.2 && < 0.3,
                        transformers >= 0.4 && < 0.6,
                        containers >=0.5 && <0.6,
-                       unbound >= 0.4 && < 0.6,
+                       unbound-generics >= 0.3 && < 0.4,
                        lens >= 4.14 && < 4.16,
                        exact-combinatorics >= 0.2 && < 0.3,
                        integer-logarithms >= 1.0 && < 1.1
@@ -81,7 +81,7 @@ executable disco
                        mtl >=2.2 && <2.3,
                        megaparsec >= 5.0 && < 5.2,
                        containers >= 0.5 && < 0.6,
-                       unbound >= 0.4 && < 0.6,
+                       unbound-generics >= 0.3 && < 0.4,
                        lens >= 4.14 && < 4.16,
                        optparse-applicative >= 0.12 && < 0.15
 

--- a/src/Disco/AST/Core.hs
+++ b/src/Disco/AST/Core.hs
@@ -1,11 +1,10 @@
+{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE UndecidableInstances  #-}
-
-{-# OPTIONS_GHC -fno-warn-orphans  #-}  -- for Alpha Rational
 
 -----------------------------------------------------------------------------
 -- |
@@ -31,14 +30,15 @@ module Disco.AST.Core
        )
        where
 
-import           Unbound.LocallyNameless
+import           GHC.Generics
+import           Unbound.Generics.LocallyNameless
 
 import           Disco.Types
 
 -- | A type of flags specifying whether to display a rational number
 --   as a fraction or a decimal.
 data RationalDisplay = Fraction | Decimal
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- | The 'Monoid' instance for 'RationalDisplay' corresponds to the
 --   idea that the result should be displayed as a decimal if any
@@ -97,7 +97,7 @@ data Core where
   -- | A type.
   CType :: Type -> Core
 
-  deriving Show
+  deriving (Show, Generic)
 
 -- | Operators that can show up in the core language.  Note that not
 --   all surface language operators show up here, since some are
@@ -130,7 +130,7 @@ data Op = OAdd     -- ^ Addition (@+@)
                    --   ordering relation.
         | OEnum
         | OCount
-  deriving Show
+  deriving (Show, Generic)
 
 -- | A branch, consisting of a list of guards and a term.
 type CBranch = Bind CGuards Core
@@ -146,7 +146,7 @@ data CGuards where
   --   pattern guards (@when@) in the surface language.  Boolean
   --   (@if@) guards are desugared to pattern matching on @true@.
   CGCons  :: Rebind (Embed Core, CPattern) CGuards -> CGuards
-  deriving Show
+  deriving (Show, Generic)
 
 -- Note: very similar to guards
 --  maybe some generalization in the future?
@@ -161,7 +161,7 @@ data CQuals where
   --   this qualifier can bind variables in the subsequent qualifiers.
   CQCons  :: Rebind CQual CQuals -> CQuals
 
-  deriving Show
+  deriving (Show, Generic)
 
 -- | A single qualifier in a list comprehension.
 data CQual where
@@ -172,7 +172,7 @@ data CQual where
   -- | A boolean guard qualfier (i.e. @x + y > 4@)
   CQGuard  :: Embed Core -> CQual
 
-  deriving Show
+  deriving (Show, Generic)
 
 -- | Core (desugared) patterns.  We only need variables, wildcards,
 --   natural numbers, and constructors.
@@ -194,11 +194,8 @@ data CPattern where
   -- | A successor pattern, @S p@.
   CPSucc :: CPattern -> CPattern
 
-  deriving Show
+  deriving (Show, Generic)
 
-derive [''RationalDisplay, ''Core, ''Op, ''CPattern, ''CGuards, ''CQual, ''CQuals]
-
-instance Alpha Rational   -- XXX duplicate orphan!
 instance Alpha RationalDisplay
 instance Alpha Core
 instance Alpha Op

--- a/src/Disco/AST/Surface.hs
+++ b/src/Disco/AST/Surface.hs
@@ -405,11 +405,21 @@ instance Alpha Pattern
 instance Alpha Quals
 instance Alpha Qual
 
-instance Subst Term Rational
-instance Subst Term Type
+-- Names for terms can't show up in Rational, Pattern, or Type
+instance Subst Term Rational where
+  subst _ _ = id
+  substs _  = id
+
+instance Subst Term Pattern where
+  subst _ _ = id
+  substs _  = id
+
+instance Subst Term Type where
+  subst _ _ = id
+  substs _  = id
+
 instance Subst Term Guards
 instance Subst Term Guard
-instance Subst Term Pattern
 instance Subst Term Quals
 instance Subst Term Qual
 instance Subst Term Side

--- a/src/Disco/AST/Surface.hs
+++ b/src/Disco/AST/Surface.hs
@@ -1,11 +1,10 @@
+{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE UndecidableInstances  #-}
-
-{-# OPTIONS_GHC -fno-warn-orphans  #-}  -- for Alpha Rational
 
 -----------------------------------------------------------------------------
 -- |
@@ -42,8 +41,9 @@ module Disco.AST.Surface
        where
 
 import qualified Data.Map                as M
+import           GHC.Generics (Generic)
 
-import           Unbound.LocallyNameless hiding (Fixity)
+import           Unbound.Generics.LocallyNameless
 
 import           Disco.Types
 
@@ -97,7 +97,7 @@ isDefn _       = False
 
 -- | Injections into a sum type (@inl@ or @inr@) have a "side" (@L@ or @R@).
 data Side = L | R
-  deriving (Show, Eq, Enum)
+  deriving (Show, Eq, Enum, Generic)
 
 -- | Unary operators.
 data UOp = Neg   -- ^ Arithmetic negation (@-@)
@@ -107,7 +107,7 @@ data UOp = Neg   -- ^ Arithmetic negation (@-@)
          | Lg    -- ^ Floor of base-2 logarithm (@lg@)
          | Floor -- ^ Floor of fractional type (@floor@)
          | Ceil  -- ^ Ceiling of fractional type (@ceiling@)
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
 
 -- | Binary operators.
 data BOp = Add     -- ^ Addition (@+@)
@@ -129,26 +129,26 @@ data BOp = Add     -- ^ Addition (@+@)
          | RelPm   -- ^ Relative primality test (@#@)
          | Choose  -- ^ Binomial and multinomial coefficients (@choose@)
          | Cons    -- ^ List cons (@::@)
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, Generic)
 
 -- | Fixities of unary operators (either pre- or postfix).
 data UFixity
   = Pre     -- ^ Unary prefix.
   | Post    -- ^ Unary postfix.
-  deriving (Eq, Ord, Enum, Bounded, Show)
+  deriving (Eq, Ord, Enum, Bounded, Show, Generic)
 
 -- | Fixity of infix binary operators (either left, right, or non-associative).
 data BFixity
   = InL   -- ^ Left-associative infix.
   | InR   -- ^ Right-associative infix.
   | In    -- ^ Infix.
-  deriving (Eq, Ord, Enum, Bounded, Show)
+  deriving (Eq, Ord, Enum, Bounded, Show, Generic)
 
 -- | Operators together with their fixity.
 data OpFixity =
     UOpF UFixity UOp
   | BOpF BFixity BOp
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- | An @OpInfo@ record contains information about an operator, such
 --   as the operator itself, its fixity, a list of concrete syntax
@@ -231,7 +231,7 @@ bopMap = M.fromList $
 -- | Type Operators
 data TyOp = Enumerate -- List all values of a type
           | Count     -- Count how many values there are of a type
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
 
 -- | Terms.
 data Term where
@@ -297,7 +297,7 @@ data Term where
 
   -- | Type ascription, @(term : type)@.
   TAscr  :: Term -> Type -> Term
-  deriving Show
+  deriving (Show, Generic)
 
 -- Note: very similar to guards
 --  maybe some generalization in the future?
@@ -312,7 +312,7 @@ data Quals where
   --   this qualifier can bind variables in the subsequent qualifiers.
   QCons  :: Rebind Qual Quals -> Quals
 
-  deriving Show
+  deriving (Show, Generic)
 
 -- | A single qualifier in a list comprehension.
 data Qual where
@@ -323,11 +323,11 @@ data Qual where
   -- | A boolean guard qualfier (i.e. @x + y > 4@)
   QGuard  :: Embed Term -> Qual
 
-  deriving Show
+  deriving (Show, Generic)
 
 data Link where
   TLink :: BOp -> Term -> Link
-  deriving Show
+  deriving (Show, Generic)
 
 -- | A branch of a case is a list of guards with an accompanying term.
 --   The guards scope over the term.  Additionally, each guard scopes
@@ -344,7 +344,7 @@ data Guards where
   -- | A single guard (@if@ or @when@) followed by more guards.
   GCons  :: Rebind Guard Guards -> Guards
 
-  deriving Show
+  deriving (Show, Generic)
 
 -- | A single guard in a branch: either an @if@ or a @when@.
 data Guard where
@@ -355,7 +355,7 @@ data Guard where
   -- | Pattern guard (@when term = pat@)
   GPat  :: Embed Term -> Pattern -> Guard
 
-  deriving Show
+  deriving (Show, Generic)
 
 -- | Patterns.
 data Pattern where
@@ -390,13 +390,9 @@ data Pattern where
   -- | List pattern @[p1, .., pn]@.
   PList :: [Pattern] -> Pattern
 
-  deriving Show
+  deriving (Show, Generic)
   -- TODO: figure out how to match on Z or Q!
 
-derive [''Side, ''UOp, ''BOp, ''TyOp, ''Term, ''Link,
-        ''Guards, ''Guard, ''Pattern, ''Qual, ''Quals]
-
-instance Alpha Rational   -- XXX orphan!
 instance Alpha Side
 instance Alpha UOp
 instance Alpha BOp

--- a/src/Disco/AST/Typed.hs
+++ b/src/Disco/AST/Typed.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric         #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
@@ -29,7 +30,8 @@ module Disco.AST.Typed
        )
        where
 
-import           Unbound.LocallyNameless
+import           GHC.Generics (Generic)
+import           Unbound.Generics.LocallyNameless
 
 import           Disco.AST.Surface
 import           Disco.Types
@@ -103,14 +105,14 @@ data ATerm where
   --   subtyping judgment.  The term has the given type T because its
   --   type is a subtype of T.
   ATSub   :: Type -> ATerm -> ATerm
-  deriving Show
+  deriving (Show, Generic)
 
   -- TODO: I don't think we are currently very consistent about using ATSub everywhere
   --   subtyping is invoked.  I am not sure how much it matters.
 
 data ALink where
   ATLink :: BOp -> ATerm -> ALink
-  deriving Show
+  deriving (Show, Generic)
 
 -- | Get the type at the root of an 'ATerm'.
 getType :: ATerm -> Type
@@ -141,7 +143,7 @@ type ABranch = Bind AGuards ATerm
 data AGuards where
   AGEmpty :: AGuards
   AGCons  :: Rebind AGuard AGuards -> AGuards
-  deriving Show
+  deriving (Show, Generic)
 
 -- | A single guard (@if@ or @when@) containing a type-annotated term.
 data AGuard where
@@ -152,7 +154,7 @@ data AGuard where
   -- | Pattern guard (@when term = pat@)
   AGPat  :: Embed ATerm -> Pattern -> AGuard
 
-  deriving Show
+  deriving (Show, Generic)
 
 -- Note: very similar to guards
 --  maybe some generalization in the future?
@@ -167,7 +169,7 @@ data AQuals where
   --   this qualifier can bind variables in the subsequent qualifiers.
   AQCons  :: Rebind AQual AQuals -> AQuals
 
-  deriving Show
+  deriving (Show, Generic)
 
 -- | A single qualifier in a list comprehension.
 data AQual where
@@ -178,11 +180,9 @@ data AQual where
   -- | A boolean guard qualfier (i.e. @x + y > 4@)
   AQGuard  :: Embed ATerm -> AQual
 
-  deriving Show
+  deriving (Show, Generic)
 
 type AProperty = Bind [(Name ATerm, Type)] ATerm
-
-derive [''ATerm, ''ALink, ''AGuards, ''AGuard, ''AQuals, ''AQual]
 
 instance Alpha ATerm
 instance Alpha ALink

--- a/src/Disco/Parser.hs
+++ b/src/Disco/Parser.hs
@@ -62,8 +62,8 @@ module Disco.Parser
 
 --import           Debug.Trace
 
-import           Unbound.LocallyNameless (Name, bind, embed, rebind,
-                                          string2Name)
+import           Unbound.Generics.LocallyNameless (Name, bind, embed, rebind,
+                                                   string2Name)
 
 import           Text.Megaparsec         hiding (runParser)
 import qualified Text.Megaparsec         as MP

--- a/src/Disco/Pretty.hs
+++ b/src/Disco/Pretty.hs
@@ -10,7 +10,7 @@ import           Data.Ratio
 import qualified Data.Map                as M
 
 import qualified Text.PrettyPrint        as PP
-import           Unbound.LocallyNameless (LFreshM, Name, lunbind, runLFreshM,
+import           Unbound.Generics.LocallyNameless (LFreshM, Name, lunbind, runLFreshM,
                                           unembed, unrebind)
 
 import           Disco.AST.Core

--- a/src/Disco/Types.hs
+++ b/src/Disco/Types.hs
@@ -1,8 +1,12 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE DeriveGeneric         #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans  #-}  -- for Generic Rational
 
 -----------------------------------------------------------------------------
 -- |
@@ -24,7 +28,9 @@ module Disco.Types
        )
        where
 
-import           Unbound.LocallyNameless
+import           GHC.Real (Ratio(..))
+import           GHC.Generics (Generic)
+import           Unbound.Generics.LocallyNameless
 
 -- | Types.
 data Type where
@@ -69,7 +75,7 @@ data Type where
   -- | Lists
   TyList   :: Type -> Type
 
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
 
 -- | Check whether a type is a numeric type (N, Z, or Q).
 isNumTy :: Type -> Bool
@@ -77,7 +83,7 @@ isNumTy ty = ty `elem` [TyN, TyZ, TyQP, TyQ]
 
 -- | Strictness of a function application or let-expression.
 data Strictness = Strict | Lazy
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 -- | Numeric types are strict, others are lazy.
 strictness :: Type -> Strictness
@@ -90,7 +96,7 @@ unpair :: Type -> [Type]
 unpair (TyPair ty1 ty2) = ty1 : unpair ty2
 unpair ty               = [ty]
 
-derive [''Type, ''Strictness]
+deriving instance Generic Rational
 
 instance Alpha Type
 instance Alpha Strictness

--- a/src/Disco/Types.hs
+++ b/src/Disco/Types.hs
@@ -6,8 +6,6 @@
 {-# LANGUAGE UndecidableInstances  #-}
 {-# LANGUAGE DeriveGeneric         #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans  #-}  -- for Generic Rational
-
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Disco.Types
@@ -28,7 +26,6 @@ module Disco.Types
        )
        where
 
-import           GHC.Real (Ratio(..))
 import           GHC.Generics (Generic)
 import           Unbound.Generics.LocallyNameless
 
@@ -95,8 +92,6 @@ strictness ty
 unpair :: Type -> [Type]
 unpair (TyPair ty1 ty2) = ty1 : unpair ty2
 unpair ty               = [ty]
-
-deriving instance Generic Rational
 
 instance Alpha Type
 instance Alpha Strictness


### PR DESCRIPTION
This shouldn't have much (if any) effect, but `unbound-generics` is a more modern reimplementation of `unbound` based on the support for generic types in GHC, instead of on the generics library `RepLib`.  In the long term, there is a much better chance the former will continue to be supported than the latter.  (I was kind of hoping switching might also fix #44 but no such luck.)

The only things to be aware of are:

1. `translate` is now `coerce`
2. When you add a new data type you may need to add `deriving Generic` to it.