### PR TITLE
Update to build with ghc-8.10.1

### DIFF
--- a/disco.cabal
+++ b/disco.cabal
@@ -252,7 +252,8 @@ library
                        TemplateHaskell
                        UndecidableInstances
 
-  build-depends:       base >=4.8 && <4.14,
+  build-depends:       base >=4.8 && <4.15,
+                       exceptions,
                        filepath,
                        directory,
                        mtl >=2.2 && <2.3,
@@ -263,11 +264,11 @@ library
                        transformers >= 0.4 && < 0.6,
                        containers >=0.5 && <0.7,
                        unbound-generics >= 0.3 && < 0.5,
-                       lens >= 4.14 && < 4.19,
+                       lens >= 4.14 && < 4.20,
                        exact-combinatorics >= 0.2 && < 0.3,
                        arithmoi >= 0.10 && < 0.11,
                        integer-logarithms >= 1.0 && < 1.1,
-                       haskeline >=0.7 && <0.8,
+                       haskeline >=0.7 && <0.9,
                        QuickCheck >= 2.9 && < 2.14,
                        fgl >= 5.5 && < 5.8,
                        optparse-applicative >= 0.12 && < 0.16
@@ -282,13 +283,13 @@ executable disco
                        disco,
                        directory,
                        filepath,
-                       haskeline >=0.7 && <0.8,
+                       haskeline >=0.7 && <0.9,
                        mtl >=2.2 && <2.3,
                        transformers >= 0.4 && < 0.6,
                        megaparsec >= 6.1.1 && < 8.1,
                        containers >= 0.5 && < 0.7,
                        unbound-generics >= 0.3 && < 0.5,
-                       lens >= 4.14 && < 4.19,
+                       lens >= 4.14 && < 4.20,
                        optparse-applicative >= 0.12 && < 0.16
 
   default-language:    Haskell2010
@@ -298,7 +299,7 @@ test-suite disco-tests
   main-is: Tests.hs
   hs-source-dirs: test
   ghc-options: -threaded
-  build-depends:    base >= 4.7 && < 4.14,
+  build-depends:    base >= 4.7 && < 4.15,
                     tasty >= 0.10 && < 1.3,
                     tasty-golden >= 2.3 && < 2.4,
                     directory >= 1.2 && < 1.4,
@@ -313,7 +314,7 @@ test-suite disco-examples
   main-is: TestExamples.hs
   hs-source-dirs: example
   ghc-options: -threaded
-  build-depends:    base >= 4.7 && < 4.14,
+  build-depends:    base >= 4.7 && < 4.15,
                     directory >= 1.2 && < 1.4,
                     filepath >= 1.4 && < 1.5,
                     process >= 1.4 && < 1.7

--- a/src/Disco/Interactive/CmdLine.hs
+++ b/src/Disco/Interactive/CmdLine.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP              #-}
+{-# LANGUAGE FlexibleContexts #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Disco.Interactive.CmdLine
@@ -34,6 +36,10 @@ import           System.Exit               (exitFailure, exitSuccess)
 
 import qualified Options.Applicative       as O
 import           System.Console.Haskeline  as H
+#if MIN_VERSION_haskeline(0,8,0)
+import qualified  Control.Monad.Catch      as H
+import            Control.Exception.Base (SomeException(..))
+#endif
 
 import           Disco.Eval
 import           Disco.Interactive.Eval

--- a/src/Disco/Interactive/Eval.hs
+++ b/src/Disco/Interactive/Eval.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP              #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Disco.Interactive.Eval
@@ -13,10 +14,17 @@
 module Disco.Interactive.Eval where
 
 import           System.Console.Haskeline                as H
+#if MIN_VERSION_haskeline(0,8,0)
+import qualified  Control.Monad.Catch                    as H
+#endif
 import           Unbound.Generics.LocallyNameless.Unsafe (unsafeUnbind)
 
 import           Control.Arrow                           ((&&&))
 import           Control.Lens                            (use, (%=), (.=))
+#if MIN_VERSION_haskeline(0,8,0)
+import           Control.Exception.Base                  (handle, IOException)
+import           Control.Monad                           (forM_)
+#endif
 import           Control.Monad.Except
 import           Data.Coerce
 import qualified Data.Map                                as M


### PR DESCRIPTION
This adds CPP to update to build with `ghc-8.10.1` in light of the changes to `unbound-generics` and `haskeline`. The CPP is only intended as a stopgap as eventually it probably makes sense to only support the latest version of GHC. I tested the build with:

```
cabal build --with-compiler=ghc-8.10.1
cabal build --with-compiler=ghc-8.8.3
stack build
```

I did not try bumping the stack lts however.