### PR TITLE
Revising sqrt, lg examples to use saturating subtraction

### DIFF
--- a/docs/tutorial/arithmetic.rst
+++ b/docs/tutorial/arithmetic.rst
@@ -168,10 +168,10 @@ might not find built in to other languages.
 
         Disco> sqrt (299^2 + 1)
         299
-        Disco> sqrt (299^2 - 1)
+        Disco> sqrt (299^2 .- 1)
         298
         Disco> lg (2^35 + 7)
         35
-        Disco> lg (2^35 - 1)
+        Disco> lg (2^35 .- 1)
         34
 


### PR DESCRIPTION
This is a revision to the docs tutorial to address issue #195 . 
Examples using `sqrt`, `lg` now use saturating subtraction because these operations are not defined over negative numbers in disco.