### PR TITLE
add :browse REPL command

### DIFF
--- a/src/Disco/Interactive/Eval.hs
+++ b/src/Disco/Interactive/Eval.hs
@@ -100,6 +100,7 @@ handleCMD s = do
     handleLine (Doc x)       = handleDocs x
     handleLine Nop           = return ()
     handleLine Help          = iputStrLn "Help!"
+    handleLine Names         = handleNames
 
 handleLet :: Name Term -> Term -> Disco IErr ()
 handleLet x t = do
@@ -306,4 +307,14 @@ handleTypeCheck t = do
   case (evalTCM $ extends ctx $ withTyDefns tymap $ inferTop t) of
     Left e        -> return.show $ e    -- XXX pretty-print
     Right (_,sig) -> renderDoc $ prettyTerm t <+> text ":" <+> prettyPolyTy sig
+
+-- | show names and types for each item in 'topCtx'
+handleNames :: Disco IErr ()
+handleNames = do
+  ctx  <- use topCtx
+  mapM_ showFn $ M.toList ctx
+  where
+      showFn (x, ty) = do
+        p  <- renderDoc . hsep $ [prettyName x, text ":", prettyPolyTy ty]
+        io . putStrLn $ p
 

--- a/src/Disco/Interactive/Parser.hs
+++ b/src/Disco/Interactive/Parser.hs
@@ -49,6 +49,7 @@ data REPLExpr =
  | Doc (Name Term)              -- Show documentation.
  | Nop                          -- No-op, e.g. if the user just enters a comment
  | Help
+ | Names
  deriving Show
 
 ------------------------------------------------------------
@@ -79,6 +80,7 @@ parseCommandArgs cmd = maybe badCmd snd $ find ((cmd `isPrefixOf`) . fst) parser
       , ("reload",  return Reload)
       , ("doc",     Doc       <$> (sc *> ident))
       , ("help",    return Help)
+      , ("names",  return Names)
       ]
 
 parseTypeTarget :: Parser Term

--- a/test/repl-names/expected
+++ b/test/repl-names/expected
@@ -1,0 +1,1 @@
+ModuleNotFound "logic.disco"

--- a/test/repl-names/input
+++ b/test/repl-names/input
@@ -1,0 +1,2 @@
+:load logic.disco
+:names

--- a/test/repl-names/logic.disco
+++ b/test/repl-names/logic.disco
@@ -1,0 +1,21 @@
+-- copied from example/logic.disco as it might change, but this file shouldn't
+-- Basic logical operators 
+
+lnot1 : B -> B
+lnot1 true  = false
+lnot1 false = true
+
+lnot2 : B -> B
+lnot2 x =
+  {? false if x,
+     true  otherwise
+  ?}
+
+implication : B -> B -> B
+implication x y =
+  {? false   if x and not y,
+     true    otherwise
+  ?}
+
+exor : B -> B -> B
+exor x y = (x && not y) || (not x && y)


### PR DESCRIPTION
does `topCtx` have everything that should be shown with `:browse`?

```
Disco> :load example/prog.disco
Loading prog.disco...
Running tests...
  fib: OK
Loaded.
Disco> :browse
f : (ℕ → ℕ) → ℕ × ℕ → ℕ → ℤ
fact : ℕ → ℕ
fact2 : ℕ → ℕ
fib : ℕ → ℕ
isEven : ℕ → Bool
isOdd : ℕ → Bool
```

I'll add tests once I'm sure the implementation is correct.

closes https://github.com/disco-lang/disco/issues/78