### PR TITLE
help impl - compile cycle example

### DIFF
--- a/disco.cabal
+++ b/disco.cabal
@@ -244,6 +244,7 @@ library
                        Disco.Interactive.Eval
                        Disco.Interactive.Parser
                        Disco.Interactive.CmdLine
+                       Disco.Interactive.Commands
 
   other-modules:       Paths_disco
   autogen-modules:     Paths_disco

--- a/disco.cabal
+++ b/disco.cabal
@@ -245,6 +245,7 @@ library
                        Disco.Interactive.Parser
                        Disco.Interactive.CmdLine
                        Disco.Interactive.Commands
+                       Disco.Interactive.REPLCommand
 
   other-modules:       Paths_disco
   autogen-modules:     Paths_disco

--- a/src/Disco/Interactive/Commands.hs
+++ b/src/Disco/Interactive/Commands.hs
@@ -1,0 +1,70 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Disco.Interactive.Comands
+-- Copyright   :  disco team and contributors
+-- Maintainer  :  byorgey@gmail.com
+--
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- Evaluation for things entered at an interactive disco prompt.
+--
+-----------------------------------------------------------------------------
+
+module Disco.Interactive.Commands (discoCommands) where
+
+import Disco.Interactive.Parser (REPLExpr)
+import           Disco.Parser (sc, ident)
+
+data ReplCommandType =
+    User
+  | Dev
+  | Advanced
+  deriving Show
+------------------------------------------------------------
+-- Commands
+------------------------------------------------------------
+data ReplCommand = ReplCommand
+  { name  :: String 
+  , shortHelp :: String
+  , longHelp :: String
+  , cmdType :: ReplCommandType
+  , cmdAction :: String -- REPLExpr -> Disco IErr ()
+  , cmdParser :: Parser REPLExpr
+  }
+
+discoCommands :: [ReplCommand]
+discoCommands = 
+  [
+  ReplCommand {
+      name = "help",
+      shortHelp = "Show help",
+      longHelp = "Show help",
+      cmdType = User,
+      cmdAction = "foo",
+      cmdParser = return Help
+    },
+    ReplCommand {
+      name = "type",
+      shortHelp = "Typecheck a term",
+      longHelp = "Typecheck a term",
+      cmdType = User,
+      cmdAction = "foo", -- REPLExpr -> Disco IErr ()
+      cmdParser = TypeCheck <$> parseTypeTarget
+    },
+    ReplCommand {
+      name = "names",
+      shortHelp = "Show all names in current scope",
+      longHelp = "Show all names in current scope",
+      cmdType = User,
+      cmdAction = "foo",
+      cmdParser = return Names
+    },
+    ReplCommand {
+      name = "defn",
+      shortHelp = "",
+      longHelp = "",
+      cmdType = User,
+      cmdAction = "foo",
+      cmdParser = ShowDefn  <$> (sc *> ident)
+    }
+  ]

--- a/src/Disco/Interactive/Commands.hs
+++ b/src/Disco/Interactive/Commands.hs
@@ -6,31 +6,14 @@
 --
 -- SPDX-License-Identifier: BSD-3-Clause
 --
--- Evaluation for things entered at an interactive disco prompt.
 --
 -----------------------------------------------------------------------------
 
-module Disco.Interactive.Commands (discoCommands) where
+module Disco.Interactive.Commands (discoCommands) where 
 
-import Disco.Interactive.Parser (REPLExpr)
+import Disco.Interactive.Parser (REPLExpr, parseTypeTarget)
 import           Disco.Parser (sc, ident)
-
-data ReplCommandType =
-    User
-  | Dev
-  | Advanced
-  deriving Show
-------------------------------------------------------------
--- Commands
-------------------------------------------------------------
-data ReplCommand = ReplCommand
-  { name  :: String 
-  , shortHelp :: String
-  , longHelp :: String
-  , cmdType :: ReplCommandType
-  , cmdAction :: String -- REPLExpr -> Disco IErr ()
-  , cmdParser :: Parser REPLExpr
-  }
+import Disco.Interactive.REPLCommand (ReplCommand)
 
 discoCommands :: [ReplCommand]
 discoCommands = 

--- a/src/Disco/Interactive/Parser.hs
+++ b/src/Disco/Interactive/Parser.hs
@@ -13,7 +13,7 @@
 
 module Disco.Interactive.Parser
   ( REPLExpr(..)
-  , letParser, commandParser, parseCommandArgs, fileParser, lineParser, parseLine, parseTypeTarget,
+  , letParser, commandParser, parseCommandArgs, fileParser, lineParser, parseLine, parseTypeTarget
   ) where
 
 import           Data.Char                        (isSpace)

--- a/src/Disco/Interactive/REPLCommand.hs
+++ b/src/Disco/Interactive/REPLCommand.hs
@@ -1,0 +1,33 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Disco.Interactive.Parser
+-- Copyright   :  disco team and contributors
+-- Maintainer  :  byorgey@gmail.com
+--
+-- SPDX-License-Identifier: BSD-3-Clause
+--
+-- Expression type and parser for things entered at an interactive disco
+-- prompt.
+--
+-----------------------------------------------------------------------------
+
+module Disco.Interactive.REPLCommand where
+
+import Disco.Interactive.Parser (Parser, REPLExpr)
+
+data ReplCommandType =
+    User
+  | Dev
+  | Advanced
+  deriving Show
+------------------------------------------------------------
+-- Commands
+------------------------------------------------------------
+data ReplCommand = ReplCommand
+  { name  :: String 
+  , shortHelp :: String
+  , longHelp :: String
+  , cmdType :: ReplCommandType
+  , cmdAction :: String -- REPLExpr -> Disco IErr ()
+  , cmdParser :: Parser REPLExpr
+  }


### PR DESCRIPTION
```
Module imports form a cycle:
         module ‘Disco.Interactive.Parser’ (src/Disco/Interactive/Parser.hs)
        imports ‘Disco.Interactive.Commands’ (src/Disco/Interactive/Commands.hs)
  which imports ‘Disco.Interactive.Parser’ (src/Disco/Interactive/Parser.hs)
```