### PR TITLE
show how to use GADTs and type indices to dispatch commands

### DIFF
--- a/src/Disco/Interactive/Commands.hs
+++ b/src/Disco/Interactive/Commands.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs     #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Disco.Interactive.Commands
@@ -10,11 +12,10 @@
 
 module Disco.Interactive.Commands
   (
-    allCommands,
-    discoBuiltins,
+    dispatch,
+    -- allCommands,
+    -- discoBuiltins,
     discoCommands,
-    getAction,
-    getCommand,
     handleLoad,
     loadFile
   ) where
@@ -31,6 +32,7 @@ import           Control.Monad.Except
 import           Data.Coerce
 import           Data.List                               (find, sortBy)
 import qualified Data.Map                                as M
+import           Data.Typeable
 import           System.FilePath                         (splitFileName)
 
 import           Disco.AST.Surface
@@ -55,74 +57,47 @@ import           Disco.Types
 import           Text.Megaparsec                         hiding (runParser)
 import           Unbound.Generics.LocallyNameless
 
--- | Allow getting an action from a REPLCommand outside of this module
-getAction :: REPLCommand -> REPLExpr -> Disco IErr ()
-getAction = action
+dispatch :: [SomeREPLCommand] -> SomeREPLExpr -> Disco IErr ()
+dispatch [] _ = return ()
+dispatch (SomeCmd c : cs) r@(SomeREPL e) = case gcast e of
+  Just e' -> action c e'
+  Nothing -> dispatch cs r
 
--- | Search for a command to handle a given REPLExpr
-getCommand :: REPLExpr -> [REPLCommand] -> Maybe REPLCommand
-getCommand r commandList = findIt $ toTag r
-          where
-            findIt tagname = find (\c -> name c == tagname) commandList
+-- allcommands :: [SomeREPLCommand]
+-- allCommands = discoBuiltins ++ discoCommands
 
-allCommands :: [REPLCommand]
-allCommands = discoBuiltins ++ discoCommands
+-- discoBuiltins :: [SomeREPLCommand]
+-- discoBuiltins =
+--   [
+--     importCmd,
+--     letCmd,
+--     nopCmd,
+--     usingCmd,
+--     evalCmd
+--   ]
 
-discoBuiltins :: [REPLCommand]
-discoBuiltins =
-  [
-    importCmd,
-    letCmd,
-    nopCmd,
-    usingCmd,
-    evalCmd
-  ]
-
-discoCommands :: [REPLCommand]
+discoCommands :: [SomeREPLCommand]
 discoCommands =
   [
-    annCmd,
-    compileCmd,
-    desugarCmd,
-    docCmd,
-    helpCmd,
-    loadCmd,
-    namesCmd,
-    parseCmd,
-    prettyCmd,
-    reloadCmd,
-    showDefnCmd,
-    typeCheckCmd
+    SomeCmd annCmd
+    -- compileCmd,
+    -- desugarCmd,
+    -- docCmd,
+    -- helpCmd,
+    -- loadCmd,
+    -- namesCmd,
+    -- parseCmd,
+    -- prettyCmd,
+    -- reloadCmd,
+    -- showDefnCmd,
+    -- typeCheckCmd
   ]
-
-
--- | Turns a REPLExpr into a single string as a way
---   to exec REPLCommand actions dynamically
-toTag :: REPLExpr -> String
-toTag (TypeCheck _) = name typeCheckCmd
-toTag (Let _ _    ) = name letCmd
-toTag (Eval     _ ) = name evalCmd
-toTag (ShowDefn _ ) = name showDefnCmd
-toTag (Parse    _ ) = name parseCmd
-toTag (Pretty   _ ) = name prettyCmd
-toTag (Ann      _ ) = name annCmd
-toTag (Desugar  _ ) = name desugarCmd
-toTag (Compile  _ ) = name compileCmd
-toTag (Import   _ ) = name importCmd
-toTag (Load     _ ) = name loadCmd
-toTag Reload        = name reloadCmd
-toTag (Doc _)       = name docCmd
-toTag Nop           = name nopCmd
-toTag Help          = name helpCmd
-toTag Names         = name namesCmd
-toTag (Using _)     = name usingCmd
-
 
 ------------------------------------------
 -- Commands
 ------------------------------------------
 
-annCmd :: REPLCommand
+annCmd :: REPLCommand 'CAnn
 annCmd =
     REPLCommand {
       name = "ann",
@@ -130,285 +105,282 @@ annCmd =
       longHelp = "",
       category = Dev,
       cmdtype = ColonCmd,
-      action = handleAnnWrapper,
+      action = handleAnn,
       parser = Ann <$> term
     }
 
 
-compileCmd :: REPLCommand
-compileCmd =
-    REPLCommand {
-      name = "compile",
-      shortHelp = "Show a compiled term",
-      longHelp = "",
-      category = Dev,
-      cmdtype = ColonCmd,
-      action = handleCompileWrapper,
-      parser = Compile   <$> term
-    }
+-- compileCmd :: REPLCommand
+-- compileCmd =
+--     REPLCommand {
+--       name = "compile",
+--       shortHelp = "Show a compiled term",
+--       longHelp = "",
+--       category = Dev,
+--       cmdtype = ColonCmd,
+--       action = handleCompileWrapper,
+--       parser = Compile   <$> term
+--     }
 
-desugarCmd :: REPLCommand
-desugarCmd =
-    REPLCommand {
-      name = "desugar",
-      shortHelp = "Show a desugared term",
-      longHelp = "",
-      category = Dev,
-      cmdtype = ColonCmd,
-      action = handleDesugar,
-      parser = Desugar   <$> term
-    }
+-- desugarCmd :: REPLCommand
+-- desugarCmd =
+--     REPLCommand {
+--       name = "desugar",
+--       shortHelp = "Show a desugared term",
+--       longHelp = "",
+--       category = Dev,
+--       cmdtype = ColonCmd,
+--       action = handleDesugar,
+--       parser = Desugar   <$> term
+--     }
 
-docCmd :: REPLCommand
-docCmd =
-    REPLCommand {
-      name = "doc",
-      shortHelp = "Show documentation",
-      longHelp = "",
-      category = User,
-      cmdtype = ColonCmd,
-      action = handleDoc,
-      parser = Doc <$> (sc *> ident)
-    }
+-- docCmd :: REPLCommand
+-- docCmd =
+--     REPLCommand {
+--       name = "doc",
+--       shortHelp = "Show documentation",
+--       longHelp = "",
+--       category = User,
+--       cmdtype = ColonCmd,
+--       action = handleDoc,
+--       parser = Doc <$> (sc *> ident)
+--     }
 
-evalCmd :: REPLCommand
-evalCmd =
-    REPLCommand {
-      name = "eval",
-      shortHelp = "Evaluate a term",
-      longHelp = "",
-      category = User,
-      cmdtype = BuiltIn,
-      action = handleEval,
-      parser = Eval <$> term
-    }
-
-
-helpCmd :: REPLCommand
-helpCmd =
-    REPLCommand {
-      name = "help",
-      shortHelp = "Show help",
-      longHelp = "",
-      category = User,
-      cmdtype = ColonCmd,
-      action = handleHelp,
-      parser = return Help
-    }
-
-importCmd :: REPLCommand
-importCmd =
-    REPLCommand {
-      name = "import",
-      shortHelp = "Import a library module",
-      longHelp = "",
-      category = User,
-      cmdtype = BuiltIn,
-      action = handleImport,
-      parser = Import <$> parseImport
-    }
-
-letCmd :: REPLCommand
-letCmd =
-    REPLCommand {
-      name = "let",
-      shortHelp = "Toplevel let-expression: for the REPL",
-      longHelp = "",
-      category = User,
-      cmdtype = BuiltIn,
-      action = handleLet,
-      parser = Load <$> fileParser
-    }
-
-loadCmd :: REPLCommand
-loadCmd =
-    REPLCommand {
-      name = "load",
-      shortHelp = "Load a file",
-      longHelp = "",
-      category = User,
-      cmdtype = ColonCmd,
-      action = handleLoadWrapper,
-      parser = Load <$> fileParser
-    }
-
-namesCmd :: REPLCommand
-namesCmd =
-    REPLCommand {
-      name = "names",
-      shortHelp = "Show all names in current scope",
-      longHelp = "",
-      category = User,
-      cmdtype = ColonCmd,
-      action = handleNames,
-      parser = return Names
-    }
-
-nopCmd :: REPLCommand
-nopCmd =
-    REPLCommand {
-      name = "nop",
-      shortHelp = "No-op, e.g. if the user just enters a comment",
-      longHelp = "",
-      category = Dev,
-      cmdtype = BuiltIn,
-      action = handleNop,
-      parser = Nop <$ (sc <* eof)
-    } -- TODO
-
-parseCmd :: REPLCommand
-parseCmd =
-    REPLCommand {
-      name = "parse",
-      shortHelp = "Show the parsed AST",
-      longHelp = "",
-      category = Dev,
-      cmdtype = ColonCmd,
-      action = handleParse,
-      parser = Parse <$> term
-    }
-
-prettyCmd :: REPLCommand
-prettyCmd =
-    REPLCommand {
-      name = "pretty",
-      shortHelp = "Pretty-print a term",
-      longHelp = "",
-      category = User,
-      cmdtype = ColonCmd,
-      action = handlePretty,
-      parser = Pretty <$> term
-    }
-
-reloadCmd :: REPLCommand
-reloadCmd =
-    REPLCommand {
-      name = "reload",
-      shortHelp = "Reloads the most recently loaded file",
-      longHelp = "",
-      category = User,
-      cmdtype = ColonCmd,
-      action = handleReload,
-      parser = return Reload
-    }
-
-showDefnCmd :: REPLCommand
-showDefnCmd =
-    REPLCommand {
-      name = "defn",
-      shortHelp = "Show a variable's definition",
-      longHelp = "",
-      category = User,
-      cmdtype = ColonCmd,
-      action = handleShowDefn,
-      parser = ShowDefn  <$> (sc *> ident)
-    }
-
-typeCheckCmd :: REPLCommand
-typeCheckCmd =
-    REPLCommand {
-        name = "type",
-        shortHelp = "Typecheck a term",
-        longHelp = "",
-        category = User,
-        cmdtype = ColonCmd,
-        action = handleTypeCheck,
-        parser = TypeCheck <$> parseTypeTarget
-        }
-
-usingCmd :: REPLCommand
-usingCmd =
-    REPLCommand {
-        name = "using",
-        shortHelp = "Enable an extension",
-        longHelp = "",
-        category = Dev,
-        cmdtype = BuiltIn,
-        action = handleUsing,
-        parser = Using <$> (reserved "using" *> parseExtName)
-        }
+-- evalCmd :: REPLCommand
+-- evalCmd =
+--     REPLCommand {
+--       name = "eval",
+--       shortHelp = "Evaluate a term",
+--       longHelp = "",
+--       category = User,
+--       cmdtype = BuiltIn,
+--       action = handleEval,
+--       parser = Eval <$> term
+--     }
 
 
-------------------------------------------
---- Command implementations
-------------------------------------------
+-- helpCmd :: REPLCommand
+-- helpCmd =
+--     REPLCommand {
+--       name = "help",
+--       shortHelp = "Show help",
+--       longHelp = "",
+--       category = User,
+--       cmdtype = ColonCmd,
+--       action = handleHelp,
+--       parser = return Help
+--     }
 
-handleAnnWrapper :: REPLExpr -> Disco IErr ()
-handleAnnWrapper (Ann t) = handleAnn t >>= iputStrLn
-handleAnnWrapper _       = return ()
+-- importCmd :: REPLCommand
+-- importCmd =
+--     REPLCommand {
+--       name = "import",
+--       shortHelp = "Import a library module",
+--       longHelp = "",
+--       category = User,
+--       cmdtype = BuiltIn,
+--       action = handleImport,
+--       parser = Import <$> parseImport
+--     }
 
-handleAnn :: Term -> Disco IErr String
-handleAnn t = do
+-- letCmd :: REPLCommand
+-- letCmd =
+--     REPLCommand {
+--       name = "let",
+--       shortHelp = "Toplevel let-expression: for the REPL",
+--       longHelp = "",
+--       category = User,
+--       cmdtype = BuiltIn,
+--       action = handleLet,
+--       parser = Load <$> fileParser
+--     }
+
+-- loadCmd :: REPLCommand
+-- loadCmd =
+--     REPLCommand {
+--       name = "load",
+--       shortHelp = "Load a file",
+--       longHelp = "",
+--       category = User,
+--       cmdtype = ColonCmd,
+--       action = handleLoadWrapper,
+--       parser = Load <$> fileParser
+--     }
+
+-- namesCmd :: REPLCommand
+-- namesCmd =
+--     REPLCommand {
+--       name = "names",
+--       shortHelp = "Show all names in current scope",
+--       longHelp = "",
+--       category = User,
+--       cmdtype = ColonCmd,
+--       action = handleNames,
+--       parser = return Names
+--     }
+
+-- nopCmd :: REPLCommand
+-- nopCmd =
+--     REPLCommand {
+--       name = "nop",
+--       shortHelp = "No-op, e.g. if the user just enters a comment",
+--       longHelp = "",
+--       category = Dev,
+--       cmdtype = BuiltIn,
+--       action = handleNop,
+--       parser = Nop <$ (sc <* eof)
+--     } -- TODO
+
+-- parseCmd :: REPLCommand
+-- parseCmd =
+--     REPLCommand {
+--       name = "parse",
+--       shortHelp = "Show the parsed AST",
+--       longHelp = "",
+--       category = Dev,
+--       cmdtype = ColonCmd,
+--       action = handleParse,
+--       parser = Parse <$> term
+--     }
+
+-- prettyCmd :: REPLCommand
+-- prettyCmd =
+--     REPLCommand {
+--       name = "pretty",
+--       shortHelp = "Pretty-print a term",
+--       longHelp = "",
+--       category = User,
+--       cmdtype = ColonCmd,
+--       action = handlePretty,
+--       parser = Pretty <$> term
+--     }
+
+-- reloadCmd :: REPLCommand
+-- reloadCmd =
+--     REPLCommand {
+--       name = "reload",
+--       shortHelp = "Reloads the most recently loaded file",
+--       longHelp = "",
+--       category = User,
+--       cmdtype = ColonCmd,
+--       action = handleReload,
+--       parser = return Reload
+--     }
+
+-- showDefnCmd :: REPLCommand
+-- showDefnCmd =
+--     REPLCommand {
+--       name = "defn",
+--       shortHelp = "Show a variable's definition",
+--       longHelp = "",
+--       category = User,
+--       cmdtype = ColonCmd,
+--       action = handleShowDefn,
+--       parser = ShowDefn  <$> (sc *> ident)
+--     }
+
+-- typeCheckCmd :: REPLCommand
+-- typeCheckCmd =
+--     REPLCommand {
+--         name = "type",
+--         shortHelp = "Typecheck a term",
+--         longHelp = "",
+--         category = User,
+--         cmdtype = ColonCmd,
+--         action = handleTypeCheck,
+--         parser = TypeCheck <$> parseTypeTarget
+--         }
+
+-- usingCmd :: REPLCommand
+-- usingCmd =
+--     REPLCommand {
+--         name = "using",
+--         shortHelp = "Enable an extension",
+--         longHelp = "",
+--         category = Dev,
+--         cmdtype = BuiltIn,
+--         action = handleUsing,
+--         parser = Using <$> (reserved "using" *> parseExtName)
+--         }
+
+
+-- ------------------------------------------
+-- --- Command implementations
+-- ------------------------------------------
+
+handleAnn :: REPLExpr 'CAnn -> Disco IErr ()
+handleAnn (Ann t) = do
     ctx   <- use topCtx
     tymap <- use topTyDefns
-    case (evalTCM $ extends ctx $ withTyDefns tymap $ inferTop t) of
+    s <- case (evalTCM $ extends ctx $ withTyDefns tymap $ inferTop t) of
         Left  e       -> return . show $ e
         Right (at, _) -> return . show $ at
+    iputStrLn s
 
-handleCompileWrapper :: REPLExpr -> Disco IErr ()
-handleCompileWrapper (Compile t) = handleCompile t >>= iputStrLn
-handleCompileWrapper _           = return ()
+-- handleCompileWrapper :: REPLExpr -> Disco IErr ()
+-- handleCompileWrapper (Compile t) = handleCompile t >>= iputStrLn
+-- handleCompileWrapper _           = return ()
 
-handleCompile :: Term -> Disco IErr String
-handleCompile t = do
-  ctx <- use topCtx
-  case evalTCM (extends ctx $ inferTop t) of
-    Left e       -> return.show $ e
-    Right (at,_) -> return.show.compileTerm $ at
+-- handleCompile :: Term -> Disco IErr String
+-- handleCompile t = do
+--   ctx <- use topCtx
+--   case evalTCM (extends ctx $ inferTop t) of
+--     Left e       -> return.show $ e
+--     Right (at,_) -> return.show.compileTerm $ at
 
-handleDesugar :: REPLExpr -> Disco IErr ()
-handleDesugar (Desugar t0) = handleDesugar_ t0 >>= iputStrLn
-  where
-    handleDesugar_ t = do
-      ctx <- use topCtx
-      case evalTCM (extends ctx $ inferTop t) of
-        Left e       -> return.show $ e
-        Right (at,_) -> renderDoc . prettyTerm . eraseDTerm . runDSM . desugarTerm $ at
-handleDesugar _ = return ()
+-- handleDesugar :: REPLExpr -> Disco IErr ()
+-- handleDesugar (Desugar t0) = handleDesugar_ t0 >>= iputStrLn
+--   where
+--     handleDesugar_ t = do
+--       ctx <- use topCtx
+--       case evalTCM (extends ctx $ inferTop t) of
+--         Left e       -> return.show $ e
+--         Right (at,_) -> renderDoc . prettyTerm . eraseDTerm . runDSM . desugarTerm $ at
+-- handleDesugar _ = return ()
 
-handleDoc :: REPLExpr -> Disco IErr ()
-handleDoc (Doc x0) =
-  handleDoc_ x0
-  where
-    handleDoc_ :: Name Term -> Disco IErr ()
-    handleDoc_ x = do
-      ctx  <- use topCtx
-      docs <- use topDocs
-      case M.lookup x ctx of
-        Nothing -> io . putStrLn $ "No documentation found for " ++ show x ++ "."
-        Just ty -> do
-          p  <- renderDoc . hsep $ [prettyName x, text ":", prettyPolyTy ty]
-          io . putStrLn $ p
-          case M.lookup x docs of
-            Just (DocString ss : _) -> io . putStrLn $ "\n" ++ unlines ss
-            _                       -> return ()
-handleDoc _ = return ()
+-- handleDoc :: REPLExpr -> Disco IErr ()
+-- handleDoc (Doc x0) =
+--   handleDoc_ x0
+--   where
+--     handleDoc_ :: Name Term -> Disco IErr ()
+--     handleDoc_ x = do
+--       ctx  <- use topCtx
+--       docs <- use topDocs
+--       case M.lookup x ctx of
+--         Nothing -> io . putStrLn $ "No documentation found for " ++ show x ++ "."
+--         Just ty -> do
+--           p  <- renderDoc . hsep $ [prettyName x, text ":", prettyPolyTy ty]
+--           io . putStrLn $ p
+--           case M.lookup x docs of
+--             Just (DocString ss : _) -> io . putStrLn $ "\n" ++ unlines ss
+--             _                       -> return ()
+-- handleDoc _ = return ()
 
 
-handleHelp :: REPLExpr -> Disco IErr ()
-handleHelp _ = do
-    iputStrLn "Commands available from the prompt:"
-    mapM_ (\c -> iputStrLn $ ":" ++ name c ++ "\t\t" ++ shortHelp c) $ sortedList allCommands
-    iputStrLn ""
-    where
-      sortedList cmds = sortBy (\x y -> compare (name x) (name y)) $ commandList cmds
-      commandList cmds = filter (\c -> category c == User && cmdtype c == ColonCmd) cmds
+-- handleHelp :: REPLExpr -> Disco IErr ()
+-- handleHelp _ = do
+--     iputStrLn "Commands available from the prompt:"
+--     mapM_ (\c -> iputStrLn $ ":" ++ name c ++ "\t\t" ++ shortHelp c) $ sortedList allCommands
+--     iputStrLn ""
+--     where
+--       sortedList cmds = sortBy (\x y -> compare (name x) (name y)) $ commandList cmds
+--       commandList cmds = filter (\c -> category c == User && cmdtype c == ColonCmd) cmds
 
-handleImport :: REPLExpr -> Disco IErr ()
-handleImport (Import i) = handleImport_ i
-                 where
-                  handleImport_ modName = catchAndPrintErrors () $ do
-                    mi <- loadDiscoModule "" modName
-                    addModule mi
-handleImport _ = return ()
+-- handleImport :: REPLExpr -> Disco IErr ()
+-- handleImport (Import i) = handleImport_ i
+--                  where
+--                   handleImport_ modName = catchAndPrintErrors () $ do
+--                     mi <- loadDiscoModule "" modName
+--                     addModule mi
+-- handleImport _ = return ()
 
--- | Parses, typechecks, and loads a module by first recursively loading any imported
---   modules by calling loadDiscoModule. If no errors are thrown, any tests present
---   in the parent module are executed.
-handleLoadWrapper :: REPLExpr -> Disco IErr ()
-handleLoadWrapper (Load file) =
-  handleLoad file >> lastFile .= Just file >>return ()
-handleLoadWrapper _ = return ()
+-- -- | Parses, typechecks, and loads a module by first recursively loading any imported
+-- --   modules by calling loadDiscoModule. If no errors are thrown, any tests present
+-- --   in the parent module are executed.
+-- handleLoadWrapper :: REPLExpr -> Disco IErr ()
+-- handleLoadWrapper (Load file) =
+--   handleLoad file >> lastFile .= Just file >>return ()
+-- handleLoadWrapper _ = return ()
 
 handleLoad :: FilePath -> Disco IErr Bool
 handleLoad fp = catchAndPrintErrors False $ do
@@ -420,77 +392,77 @@ handleLoad fp = catchAndPrintErrors False $ do
     garbageCollect
     return t
 
-handleNop :: REPLExpr -> Disco IErr ()
-handleNop _ = return ()
+-- handleNop :: REPLExpr -> Disco IErr ()
+-- handleNop _ = return ()
 
-handleParse :: REPLExpr -> Disco IErr ()
-handleParse (Parse t) = iprint $ t
-handleParse _         = return ()
+-- handleParse :: REPLExpr -> Disco IErr ()
+-- handleParse (Parse t) = iprint $ t
+-- handleParse _         = return ()
 
-handlePretty :: REPLExpr -> Disco IErr ()
-handlePretty (Pretty t) = renderDoc (prettyTerm t) >>= iputStrLn
-handlePretty _          = return ()
+-- handlePretty :: REPLExpr -> Disco IErr ()
+-- handlePretty (Pretty t) = renderDoc (prettyTerm t) >>= iputStrLn
+-- handlePretty _          = return ()
 
-handleReload :: REPLExpr -> Disco IErr ()
-handleReload _ = do
-                  file <- use lastFile
-                  case file of
-                    Nothing -> iputStrLn "No file to reload."
-                    Just f  -> handleLoad f >> return()
+-- handleReload :: REPLExpr -> Disco IErr ()
+-- handleReload _ = do
+--                   file <- use lastFile
+--                   case file of
+--                     Nothing -> iputStrLn "No file to reload."
+--                     Just f  -> handleLoad f >> return()
 
-handleShowDefn :: REPLExpr -> Disco IErr ()
-handleShowDefn (ShowDefn x0) =
-  handleShowDefn_ x0 >>= iputStrLn
-  where
-  handleShowDefn_ x = do
-    defns   <- use topDefns
-    tyDefns <- use topTyDefns
-    case M.lookup (coerce x) defns of
-      Just d  -> renderDoc $ prettyDefn d
-      Nothing -> case M.lookup tyname tyDefns of
-        Just t  -> renderDoc $ prettyTyDef tyname t
-        Nothing -> return $ "No definition for " ++ show x
-    where
-      tyname = name2String x
-handleShowDefn _ = return ()
+-- handleShowDefn :: REPLExpr -> Disco IErr ()
+-- handleShowDefn (ShowDefn x0) =
+--   handleShowDefn_ x0 >>= iputStrLn
+--   where
+--   handleShowDefn_ x = do
+--     defns   <- use topDefns
+--     tyDefns <- use topTyDefns
+--     case M.lookup (coerce x) defns of
+--       Just d  -> renderDoc $ prettyDefn d
+--       Nothing -> case M.lookup tyname tyDefns of
+--         Just t  -> renderDoc $ prettyTyDef tyname t
+--         Nothing -> return $ "No definition for " ++ show x
+--     where
+--       tyname = name2String x
+-- handleShowDefn _ = return ()
 
 
-handleTypeCheck :: REPLExpr -> Disco IErr ()
-handleTypeCheck (TypeCheck t0) =
-    handleTypeCheck_ t0 >>= iputStrLn
-    where
-    handleTypeCheck_ t = do
-      ctx <- use topCtx
-      tymap <- use topTyDefns
-      case (evalTCM $ extends ctx $ withTyDefns tymap $ inferTop t) of
-        Left e        -> return.show $ e    -- XXX pretty-print
-        Right (_,sig) -> renderDoc $ prettyTerm t <+> text ":" <+> prettyPolyTy sig
-handleTypeCheck _ = return ()
+-- handleTypeCheck :: REPLExpr -> Disco IErr ()
+-- handleTypeCheck (TypeCheck t0) =
+--     handleTypeCheck_ t0 >>= iputStrLn
+--     where
+--     handleTypeCheck_ t = do
+--       ctx <- use topCtx
+--       tymap <- use topTyDefns
+--       case (evalTCM $ extends ctx $ withTyDefns tymap $ inferTop t) of
+--         Left e        -> return.show $ e    -- XXX pretty-print
+--         Right (_,sig) -> renderDoc $ prettyTerm t <+> text ":" <+> prettyPolyTy sig
+-- handleTypeCheck _ = return ()
 
-handleUsing :: REPLExpr -> Disco IErr ()
-handleUsing (Using e) = enabledExts %= addExtension e
-handleUsing _         = return ()
+-- handleUsing :: REPLExpr -> Disco IErr ()
+-- handleUsing (Using e) = enabledExts %= addExtension e
+-- handleUsing _         = return ()
 
--- | show names and types for each item in 'topCtx'
-handleNames :: REPLExpr -> Disco IErr ()
-handleNames _ = do
-  ctx  <- use topCtx
-  mapM_ showFn $ M.toList ctx
-  where
-      showFn (x, ty) = do
-        p  <- renderDoc . hsep $ [prettyName x, text ":", prettyPolyTy ty]
-        io . putStrLn $ p
+-- -- | show names and types for each item in 'topCtx'
+-- handleNames :: REPLExpr -> Disco IErr ()
+-- handleNames _ = do
+--   ctx  <- use topCtx
+--   mapM_ showFn $ M.toList ctx
+--   where
+--       showFn (x, ty) = do
+--         p  <- renderDoc . hsep $ [prettyName x, text ":", prettyPolyTy ty]
+--         io . putStrLn $ p
 
-------------------------------------------
---- Util functions
-------------------------------------------
+-- ------------------------------------------
+-- --- Util functions
+-- ------------------------------------------
 
-addModule :: ModuleInfo -> Disco IErr ()
-addModule mi = do
-  curMI <- use topModInfo
-  mi' <- adaptError TypeCheckErr $ combineModuleInfo [curMI, mi]
-  topModInfo .= mi'
-  populateCurrentModuleInfo
+-- addModule :: ModuleInfo -> Disco IErr ()
+-- addModule mi = do
+--   curMI <- use topModInfo
+--   mi' <- adaptError TypeCheckErr $ combineModuleInfo [curMI, mi]
+--   topModInfo .= mi'
+--   populateCurrentModuleInfo
 
 
 loadFile :: FilePath -> Disco IErr (Maybe String)
@@ -589,43 +561,43 @@ prettyCounterexample ctx env
       Just val -> val
       Nothing  -> error $ "Failed M.! with key " ++ show k ++ " in map " ++ show m
 
-handleLet :: REPLExpr -> Disco IErr ()
-handleLet (Let nt t0) =
-    handleLet_ nt t0
-    where
-      handleLet_ x t = do
-        ctx <- use topCtx
-        tymap <- use topTyDefns
-        let mat = evalTCM (extends ctx $ withTyDefns tymap $ inferTop t)
-        case mat of
-          Left e -> io.print $ e   -- XXX pretty print
-          Right (at, sig) -> do
-            let c = compileTerm at
-            thnk <- withTopEnv (mkValue c)
-            topCtx   %= M.insert x sig
-              -- XXX ability to define more complex things at REPL prompt, with patterns etc.
-            topDefns %= M.insert (coerce x) (Defn (coerce x) [] (getType at) [bind [] at])
-            topEnv   %= M.insert (coerce x) thnk
-handleLet _ = return ()
+-- handleLet :: REPLExpr -> Disco IErr ()
+-- handleLet (Let nt t0) =
+--     handleLet_ nt t0
+--     where
+--       handleLet_ x t = do
+--         ctx <- use topCtx
+--         tymap <- use topTyDefns
+--         let mat = evalTCM (extends ctx $ withTyDefns tymap $ inferTop t)
+--         case mat of
+--           Left e -> io.print $ e   -- XXX pretty print
+--           Right (at, sig) -> do
+--             let c = compileTerm at
+--             thnk <- withTopEnv (mkValue c)
+--             topCtx   %= M.insert x sig
+--               -- XXX ability to define more complex things at REPL prompt, with patterns etc.
+--             topDefns %= M.insert (coerce x) (Defn (coerce x) [] (getType at) [bind [] at])
+--             topEnv   %= M.insert (coerce x) thnk
+-- handleLet _ = return ()
 
-handleEval :: REPLExpr -> Disco IErr ()
-handleEval (Eval e) = evalTerm e
-handleEval _        = return ()
+-- handleEval :: REPLExpr -> Disco IErr ()
+-- handleEval (Eval e) = evalTerm e
+-- handleEval _        = return ()
 
-evalTerm :: Term -> Disco IErr ()
-evalTerm t = do
-  ctx   <- use topCtx
-  tymap <- use topTyDefns
-  case evalTCM (extends ctx $ withTyDefns tymap $ inferTop t) of
-    Left e   -> iprint e    -- XXX pretty-print
-    Right (at,_) ->
-      let ty = getType at
-          c  = compileTerm at
-      in do
-        v <- withTopEnv $ do
-          cv <- mkValue c
-          prettyValue ty cv
-          return cv
-        topCtx %= M.insert (string2Name "it") (toPolyType ty)
-        topEnv %= M.insert (string2Name "it") v
-        garbageCollect
+-- evalTerm :: Term -> Disco IErr ()
+-- evalTerm t = do
+--   ctx   <- use topCtx
+--   tymap <- use topTyDefns
+--   case evalTCM (extends ctx $ withTyDefns tymap $ inferTop t) of
+--     Left e   -> iprint e    -- XXX pretty-print
+--     Right (at,_) ->
+--       let ty = getType at
+--           c  = compileTerm at
+--       in do
+--         v <- withTopEnv $ do
+--           cv <- mkValue c
+--           prettyValue ty cv
+--           return cv
+--         topCtx %= M.insert (string2Name "it") (toPolyType ty)
+--         topEnv %= M.insert (string2Name "it") v
+--         garbageCollect

--- a/src/Disco/Interactive/Eval.hs
+++ b/src/Disco/Interactive/Eval.hs
@@ -52,9 +52,4 @@ handleCMD s = do
     exts <- use enabledExts
     case (parseLine discoCommands exts s) of
       Left msg -> io $ putStrLn msg
-      Right l -> handleLine l `catchError` (io . print  {- XXX pretty-print error -})
-  where
-    handleLine :: REPLExpr -> Disco IErr ()
-    handleLine r = case getCommand r allCommands of
-                    Just c  -> getAction c r
-                    Nothing -> return ()
+      Right l -> dispatch discoCommands l `catchError` (io . print  {- XXX pretty-print error -})

--- a/src/Disco/Interactive/Types.hs
+++ b/src/Disco/Interactive/Types.hs
@@ -9,8 +9,14 @@
 --
 -----------------------------------------------------------------------------
 
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE GADTs              #-}
+{-# LANGUAGE KindSignatures     #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
 module Disco.Interactive.Types
-  ( REPLExpr(..), REPLCommand(..), REPLCommandCategory(..), REPLCommandType(..))
+  ( CmdTag(..), REPLExpr(..), SomeREPLExpr(..), REPLCommand(..), SomeREPLCommand(..)
+  , REPLCommandCategory(..), REPLCommandType(..))
   where
 
 import           Unbound.Generics.LocallyNameless
@@ -20,29 +26,36 @@ import           Disco.Eval                       (Disco, IErr)
 import           Disco.Extensions
 import           Disco.Parser
 
+import           Data.Typeable
+
 ------------------------------------------------------------
 -- REPL expression type
 ------------------------------------------------------------
 
-data REPLExpr =
-   Using Ext                    -- Enable an extension
- | Let (Name Term) Term         -- Toplevel let-expression: for the REPL
- | TypeCheck Term               -- Typecheck a term
- | Eval Term                    -- Evaluate a term
- | ShowDefn (Name Term)         -- Show a variable's definition
- | Parse Term                   -- Show the parsed AST
- | Pretty Term                  -- Pretty-print a term
- | Ann Term                     -- Show type-annotated typechecked term
- | Desugar Term                 -- Show a desugared term
- | Compile Term                 -- Show a compiled term
- | Import String                -- Import a library module.
- | Load FilePath                -- Load a file.
- | Reload                       -- Reloads the most recently loaded file.
- | Doc (Name Term)              -- Show documentation.
- | Nop                          -- No-op, e.g. if the user just enters a comment
- | Help
- | Names
- deriving Show
+data REPLExpr :: CmdTag -> * where
+  Using     :: Ext -> REPLExpr 'CUsing             -- Enable an extension
+  Let       :: Name Term -> Term -> REPLExpr 'CLet -- Toplevel let-expression: for the REPL
+  TypeCheck :: Term -> REPLExpr 'CTypeCheck        -- Typecheck a term
+  Eval      :: Term -> REPLExpr 'CEval             -- Evaluate a term
+  ShowDefn  :: Name Term -> REPLExpr 'CShowDefn    -- Show a variable's definition
+  Parse     :: Term -> REPLExpr 'CParse            -- Show the parsed AST
+  Pretty    :: Term -> REPLExpr 'CPretty           -- Pretty-print a term
+  Ann       :: Term -> REPLExpr 'CAnn              -- Show type-annotated typechecked term
+  Desugar   :: Term -> REPLExpr 'CDesugar          -- Show a desugared term
+  Compile   :: Term -> REPLExpr 'CCompile          -- Show a compiled term
+  Import    :: String -> REPLExpr 'CImport         -- Import a library module.
+  Load      :: FilePath -> REPLExpr 'CLoad         -- Load a file.
+  Reload    :: REPLExpr 'CReload                   -- Reloads the most recently loaded file.
+  Doc       :: Name Term -> REPLExpr 'CDoc         -- Show documentation.
+  Nop       :: REPLExpr 'CNop                      -- No-op, e.g. if the user
+                                                   -- just enters a comment
+  Help      :: REPLExpr 'CHelp
+  Names     :: REPLExpr 'CNames
+
+deriving instance Show (REPLExpr c)
+
+data SomeREPLExpr where
+  SomeREPL :: Typeable c => REPLExpr c -> SomeREPLExpr
 
 ------------------------------------------------------------
 -- REPL command types
@@ -62,12 +75,20 @@ data REPLCommandType =
 -- Commands
 ------------------------------------------------------------
 
-data REPLCommand = REPLCommand
+data REPLCommand (c :: CmdTag) = REPLCommand
   { name      :: String
   , shortHelp :: String
   , longHelp  :: String
   , category  :: REPLCommandCategory
   , cmdtype   :: REPLCommandType
-  , action    :: REPLExpr -> Disco IErr ()
-  , parser    :: Parser REPLExpr
+  , action    :: REPLExpr c -> Disco IErr ()
+  , parser    :: Parser (REPLExpr c)
   }
+
+data CmdTag = CUsing | CLet | CTypeCheck | CEval | CShowDefn
+  | CParse | CPretty | CAnn | CDesugar | CCompile | CImport | CLoad
+  | CReload | CDoc | CNop | CHelp | CNames
+  deriving (Show, Eq, Typeable)
+
+data SomeREPLCommand where
+  SomeCmd :: Typeable c => REPLCommand c -> SomeREPLCommand


### PR DESCRIPTION
This way we don't need the `toTag stuff`, and we don't need any
`handleXXXWrappe`r functions that match on just one thing and `return ()`
for everything else.

The key idea is that both commands and and REPLExprs are indexed by an
enumeration, so each REPLExpr and the command that can process it
share a label.  The 'dispatch' function uses the magic 'gcast'
function from Data.Typeable to find the first command which has a
matching type index, and uses its 'action' to process
the (guaranteed-matching) REPLExpr.  Each 'handleXXX' function
declares that it only handles REPLExprs with a particular type index,
which means it only has to match on the one constructor which actually
has that type index.