### PR TITLE
parser: allow operator characters following a wildcard

### DIFF
--- a/src/Disco/Parser.hs
+++ b/src/Disco/Parser.hs
@@ -497,7 +497,7 @@ parseAtom = label "expression" $
 --   an identifier.
 parseWild :: Parser ()
 parseWild = (lexeme . try . void) $
-  string "_" <* notFollowedBy (alphaNumChar <|> oneOf "_'" <|> oneOf opChar)
+  string "_" <* notFollowedBy (alphaNumChar <|> oneOf "_'")
 
 -- | Parse a standalone operator name with tildes indicating argument
 --   slots, e.g. ~+~ for the addition operator.

--- a/test/syntax-lambda/expected
+++ b/test/syntax-lambda/expected
@@ -8,3 +8,5 @@ let f = (λx. x + 1 : ℕ → ℕ) in f : ℕ → ℕ
 [false, true, true]
 let f = λ(g : ℤ → ℕ → Bool). [g 1 1, g 1 2, g (-1) 0] in f (λ x, (y : ℤ). x + 1 == y) : List Bool
 3
+TAbs_ Lam () (<[PWild_ ()]> TNat_ () 3)
+3

--- a/test/syntax-lambda/input
+++ b/test/syntax-lambda/input
@@ -8,3 +8,5 @@ let q = \ (f : (N -> N) -> N) . f (\(x:N) . x*x) in q (\g. g 1 + g 2)
 let f = \(g : Z -> N -> B).[g 1 1, g 1 2, g (-1) 0] in f (\x, y:Z. x + 1 == y)
 :type let f = \(g : Z -> N -> B).[g 1 1, g 1 2, g (-1) 0] in f (\x, y:Z. x + 1 == y)
 let f = (\x.\y.x+y : N -> N -> N) in f 1 2
+:parse \_.3
+(\_.3) "hello"


### PR DESCRIPTION
See the discussion at #246.  This change doesn't seem to break anything else, and I can't think of any reason operator characters should be disallowed after a wildcard.