### PR TITLE
enumerate for infinite types

### DIFF
--- a/src/Disco/Eval.hs
+++ b/src/Disco/Eval.hs
@@ -500,6 +500,13 @@ initDiscoState = DiscoState
 type Disco e = StateT (DiscoState e) (ReaderT Env (ExceptT e (LFreshMT IO)))
 
 ------------------------------------------------------------
+-- Some needed instances.
+
+-- This should eventually move into unbound-generics.
+instance MonadFail m => MonadFail (LFreshMT m) where
+  fail = LFreshMT . Fail.fail
+
+------------------------------------------------------------
 -- Lenses for state
 ------------------------------------------------------------
 

--- a/src/Disco/Eval.hs
+++ b/src/Disco/Eval.hs
@@ -500,13 +500,6 @@ initDiscoState = DiscoState
 type Disco e = StateT (DiscoState e) (ReaderT Env (ExceptT e (LFreshMT IO)))
 
 ------------------------------------------------------------
--- Some needed instances.
-
--- This should eventually move into unbound-generics.
-instance MonadFail m => MonadFail (LFreshMT m) where
-  fail = LFreshMT . Fail.fail
-
-------------------------------------------------------------
 -- Lenses for state
 ------------------------------------------------------------
 

--- a/src/Disco/Interpret/Core.hs
+++ b/src/Disco/Interpret/Core.hs
@@ -1084,9 +1084,7 @@ countOp v = error $ "Impossible! countOp on non-type " ++ show v
 
 -- | Perform an enumeration of the values of a given type.
 enumOp :: Value -> Disco IErr Value
-enumOp (VType ty)
-  | isFiniteTy ty = toDiscoList (enumerateType ty)
-  | otherwise     = throwError $ InfiniteTy ty
+enumOp (VType ty) = toDiscoList (enumerateType ty)
 enumOp v = error $ "Impossible! enumOp on non-type " ++ show v
 
 -- | Perform a square root operation. If the program typechecks,

--- a/test/types-ops/expected
+++ b/test/types-ops/expected
@@ -1,3 +1,4 @@
+Loading list.disco...
 right(0)
 right(1)
 right(2)
@@ -18,7 +19,10 @@ right(1)
 []
 [[]]
 [[]]
-InfiniteTy (TyCon (CContainer (ABase CtrList)) [TyAtom (ABase Unit)])
+[false, true]
+[[], [()], [(), ()], [(), (), ()], [(), (), (), ()]]
+[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+[(0, 0), (0, 1), (1, 0), (0, 2), (1, 1), (2, 0)]
 []
 []
 [<Void → ℕ>]

--- a/test/types-ops/input
+++ b/test/types-ops/input
@@ -1,3 +1,4 @@
+import list
 count Void
 count Unit
 count Bool
@@ -18,7 +19,10 @@ enumerate (Unit + Bool)
 enumerate (Void * Unit)
 enumerate (List Void)
 enumerate (List (Void * Bool + Void))
-enumerate (List Unit)
+enumerate(Bool)
+take(5, enumerate(List Unit))
+take(10, enumerate(N))
+take(6, enumerate(N * N))
 enumerate (Void * Nat)
 enumerate (Nat * Void)
 enumerate (Void -> Nat)


### PR DESCRIPTION
Enumeration already works for infinite types, but the primitive
previously had a check to fail when the type was infinite.  This
just removes that check.

Fixes #91