### PR TITLE
Some updates + additions to the reference documentation

### DIFF
--- a/docs/reference/.#string.rst
+++ b/docs/reference/.#string.rst
@@ -1,0 +1,1 @@
+brent@diophantus.10955:1721342881

--- a/docs/reference/.#string.rst
+++ b/docs/reference/.#string.rst
@@ -1,1 +1,0 @@
-brent@diophantus.10955:1721342881

--- a/docs/reference/collections.rst
+++ b/docs/reference/collections.rst
@@ -1,25 +1,19 @@
 Collections
 ===========
 
-Disco has several built-in collection types (such as :doc:`lists
-<list>`, :doc:`bags <bag>`, and :doc:`sets <set>`) which represent
-collections of values.  The pages linked below explain the different
-ways to create and use collections, and the operations which can be
-used on them.
+Disco has several built-in :doc:`collection types <collection-types>`
+(such as :doc:`lists <list>`, :doc:`bags <bag>`, and :doc:`sets <set>`)
+which represent collections of values.  The pages linked below explain
+the different ways to create and use collections, and the operations
+which can be used on them.
 
 .. toctree::
 
-   list
-   string
-   set
-   bag
    size
    cp
    ellipsis
-   collection-ops
+   set-ops
    power
-   each
-   filter
    comprehension
    boom
    map

--- a/docs/reference/comprehension.rst
+++ b/docs/reference/comprehension.rst
@@ -1,7 +1,7 @@
 Comprehensions
 ==============
 
-*Comprehension* notation can be used to describe :doc:`collections <collections>` such as
+*Comprehension* notation can be used to describe collections such as
 :doc:`sets <set>` or :doc:`lists <list>`.  The general syntax for a
 set comprehension is
 
@@ -15,8 +15,7 @@ some examples below; for the precise details, see the
 `Details`_ section.
 
 :doc:`List <list>` comprehensions are similar, but use square brackets
-(``[``, ``]``) instead of curly braces (``{``, ``}``); :doc:`bag
-<bag>` comprehensions use bag brackets (``⟅``, ``⟆``).
+(``[``, ``]``) instead of curly braces (``{``, ``}``).
 
 Examples
 --------
@@ -97,7 +96,7 @@ Specification
 .. note::
 
    In case you are curious about the precise definition and are not
-   afraid of the details, the exact way that comprehensions
+   afraid of the details, the exact way that set comprehensions
    work can be defined by the following three equations, making use of
    the standard functions :doc:`each <each>` and ``$join``:
 

--- a/docs/reference/comprehension.rst
+++ b/docs/reference/comprehension.rst
@@ -105,29 +105,29 @@ Specification
    * ``{ e | x in xs, gs } = $join(each(\x. {e | gs}, xs))``
    * ``{ e | g, gs } = {? { e | gs } if g, {} otherwise ?}``
 
-   ``$join`` is not directly available to users, but can be accessed
-   by enabling the ``Primitives`` :doc:`extension <extensions>`.  In
-   general, ``$join`` turns a thing-of-things into a thing
-   (list-of-lists into a list, bag-of-bags into a bag, *etc.*).
+    ``$join`` is not directly available to users, but can be accessed
+    by enabling the ``Primitives`` :doc:`extension <extensions>`.  In
+    general, ``$join`` turns a thing-of-things into a thing
+    (list-of-lists into a list, bag-of-bags into a bag, *etc.*).
 
-   - For lists, ``$join`` is equivalent to ``concat``.
+    - For lists, ``$join`` is equivalent to ``concat``.
 
-       ::
+        ::
 
-          Disco> $join [[1,2,3], [4], [5,6]]
-          [1, 2, 3, 4, 5, 6]
+           Disco> $join [[1,2,3], [4], [5,6]]
+           [1, 2, 3, 4, 5, 6]
 
-   - For sets, ``$join`` is equivalent to ``unions``.
+    - For sets, ``$join`` is equivalent to ``unions``.
 
-       ::
+        ::
 
-          Disco> $join {{1,2,3}, {2,3,4}, {3,5,6}}
-          {1, 2, 3, 4, 5, 6}
+           Disco> $join {{1,2,3}, {2,3,4}, {3,5,6}}
+           {1, 2, 3, 4, 5, 6}
 
-   - For bags, ``$join`` is equivalent to a straightforward
-     generalization of ``unions`` to work on bags instead of sets.
+    - For bags, ``$join`` is equivalent to a straightforward
+      generalization of ``unions`` to work on bags instead of sets.
 
-       ::
+        ::
 
-          Disco> $join (bag [bag [1,1,2], bag [1,1,2], bag [2,3,4], bag [2,5,6]])
-          ⟅1 # 4, 2 # 4, 3, 4, 5, 6⟆
+           Disco> $join (bag [bag [1,1,2], bag [1,1,2], bag [2,3,4], bag [2,5,6]])
+           ⟅1 # 4, 2 # 4, 3, 4, 5, 6⟆


### PR DESCRIPTION
Enhanced or added reference documentation on:

- REPL commands
- containers (bags, Boom hierarchy)
- comprehensions
- `each` function
- a bunch of other stuff

As soon as we merge this it means the documentation on readthedocs will be updated, so *in theory* we shouldn't merge this until making a new release; but I'd rather just get things merged.  No one will really be looking at the docs right now.