### PR TITLE
Print environment for crashing tests

### DIFF
--- a/src/Disco/Property.hs
+++ b/src/Disco/Property.hs
@@ -50,7 +50,7 @@ invertMotive (SearchMotive (a, b)) = SearchMotive (not a, b)
 --   the explanation unchanged.
 invertPropResult :: TestResult -> TestResult
 invertPropResult res@(TestResult b r env)
-  | TestRuntimeError _ <- r = res
+  | TestRuntimeError {} <- r = res
   | otherwise = TestResult (not b) r env
 
 randomLarge :: Member Random r => [Integer] -> Sem r [Integer]
@@ -86,39 +86,38 @@ prettyTestReason ::
   Bool ->
   AProperty ->
   TestReason ->
+  TestEnv ->
   Sem r (Doc ann)
-prettyTestReason _ _ TestBool = empty
-prettyTestReason b (ATAbs _ _ body) (TestFound (TestResult b' r' env)) = do
+prettyTestReason _ _ TestBool _ = empty
+prettyTestReason b (ATAbs _ _ body) (TestFound (TestResult b' r' env')) env = do
   lunbind body $ \(_, p) ->
     prettyTestEnv ("Found " ++ if b then "example:" else "counterexample:") env
-      $+$ prettyTestReason b' p r'
-prettyTestReason b _ (TestNotFound Exhaustive)
+      $+$ prettyTestReason b' p r' env'
+prettyTestReason b _ (TestNotFound Exhaustive) _
   | b = "No counterexamples exist; all possible values were checked."
   | otherwise = "No example exists; all possible values were checked."
-prettyTestReason b _ (TestNotFound (Randomized n m))
+prettyTestReason b _ (TestNotFound (Randomized n m)) _
   | b = "Checked" <+> text (show (n + m)) <+> "possibilities without finding a counterexample."
   | otherwise = "No example was found; checked" <+> text (show (n + m)) <+> "possibilities."
-prettyTestReason _ _ (TestCmp _ t a1 a2) =
+prettyTestReason _ _ (TestCmp _ t a1 a2) _ =
   bulletList
     "-"
     [ "Left side:  " <> prettyValue t a1
     , "Right side: " <> prettyValue t a2
     ]
-prettyTestReason _ _ (TestRuntimeError ee) =
+prettyTestReason _ _ (TestRuntimeError ee) env =
   nest 2 $
     "Test failed with an error:"
       $+$ pretty (EvalErr ee)
--- \$+$
--- prettyTestEnv "Example inputs that caused the error:" env
--- See #364
-prettyTestReason b (ATApp _ (ATPrim _ (PrimBOp _)) (ATTup _ [p1, p2])) (TestBin _ tr1 tr2) =
+      $+$ prettyTestEnv "Example inputs that caused the error:" env
+prettyTestReason _ (ATApp _ (ATPrim _ (PrimBOp _)) (ATTup _ [p1, p2])) (TestBin _ tr1 tr2) _ =
   bulletList
     "-"
-    [ nest 2 $ prettyTestResult' b p1 tr1
-    , nest 2 $ prettyTestResult' b p2 tr2
+    [ nest 2 $ prettyTestResult p1 tr1
+    , nest 2 $ prettyTestResult p2 tr2
     ]
 -- See Note [prettyTestReason fallback]
-prettyTestReason _ _ _ = empty
+prettyTestReason _ _ _ _ = empty
 
 -- ~~~~ Note [prettyTestReason fallback]
 --
@@ -140,22 +139,14 @@ prettyTestReason _ _ _ = empty
 -- of the test result.  So we just give up and decline to print a
 -- reason.
 
-prettyTestResult' ::
-  Members '[Input TyDefCtx, LFresh, Reader PA] r =>
-  Bool ->
-  AProperty ->
-  TestResult ->
-  Sem r (Doc ann)
-prettyTestResult' _ prop (TestResult bool tr _) =
-  prettyResultCertainty tr prop (map toLower (show bool))
-    $+$ prettyTestReason bool prop tr
-
 prettyTestResult ::
   Members '[Input TyDefCtx, LFresh, Reader PA] r =>
   AProperty ->
   TestResult ->
   Sem r (Doc ann)
-prettyTestResult prop (TestResult b r env) = prettyTestResult' b prop (TestResult b r env)
+prettyTestResult prop (TestResult bool tr env) =
+  prettyResultCertainty tr prop (map toLower (show bool))
+    $+$ prettyTestReason bool prop tr env
 
 prettyTestEnv ::
   Members '[Input TyDefCtx, LFresh, Reader PA] r =>

--- a/src/Disco/Value.hs
+++ b/src/Disco/Value.hs
@@ -366,7 +366,7 @@ data TestResult = TestResult Bool TestReason TestEnv
 
 -- | Whether the property test resulted in a runtime error.
 testIsError :: TestResult -> Bool
-testIsError (TestResult _ (TestRuntimeError _) _) = True
+testIsError (TestResult _ (TestRuntimeError {}) _) = True
 testIsError _ = False
 
 -- | Whether the property test resulted in success.
@@ -389,7 +389,7 @@ resultIsCertain TestCmp {} = True
 resultIsCertain (TestNotFound Exhaustive) = True
 resultIsCertain (TestNotFound (Randomized _ _)) = False
 resultIsCertain (TestFound r) = testIsCertain r
-resultIsCertain (TestRuntimeError _) = True
+resultIsCertain (TestRuntimeError {}) = True
 resultIsCertain (TestBin op tr1 tr2)
   | c1 && c2 = True
   | c1 && ((op == LOr) == ok1) = True
@@ -412,7 +412,7 @@ data ValProp
   deriving (Show)
 
 extendPropEnv :: TestEnv -> ValProp -> ValProp
-extendPropEnv g (VPDone (TestResult b r e)) = VPDone (TestResult b r (g P.<> e))
+extendPropEnv g (VPDone res) = VPDone (extendResultEnv g res)
 extendPropEnv g (VPSearch sm tys v e) = VPSearch sm tys v (g P.<> e)
 extendPropEnv g (VPBin op vp1 vp2) = VPBin op (extendPropEnv g vp1) (extendPropEnv g vp2)
 

--- a/test/prop-fail/expected
+++ b/test/prop-fail/expected
@@ -14,6 +14,9 @@ Running tests...
   - Certainly false: ∀a, b. divide(a)(b) * b == a
     Test failed with an error:
       Error: division by zero.
+      Example inputs that caused the error:
+        a = 0
+        b = 0
   - Certainly false: ∀a. divide(a)(2) < a
     Found counterexample:
       a = 0


### PR DESCRIPTION
Fixes #364.  Also cleans up test result printing code a bit.